### PR TITLE
Use a native license issued for app://obsidian.md

### DIFF
--- a/src/components/TldrawApp.tsx
+++ b/src/components/TldrawApp.tsx
@@ -7,6 +7,7 @@ import { TldrawInObsidianPluginProvider } from 'src/contexts/plugin'
 import { useClickAwayListener } from 'src/hooks/useClickAwayListener'
 import { useTldrawAppEffects } from 'src/hooks/useTldrawAppHook'
 import TldrawPlugin from 'src/main'
+import { TLDRAW_LICENSE_KEY } from 'src/tldraw/license'
 import {
 	CREATE_PAGE_ACTION,
 	PLUGIN_ACTION_TOGGLE_ZOOM_LOCK,
@@ -437,7 +438,7 @@ const TldrawApp = ({
 				autoFocus={false}
 				onMount={setAppState}
 				tools={tools}
-				licenseKey="tldraw-tldraw-2026-07-10/WyIyU3h6ZzhTZyIsWyIqLnRsZHJhdy5jb20iLCIqLnRsZHJhdy5kZXYiLCIqLnRsZHJhdy5jbHViIiwiKi50bGRyYXcud29ya2Vycy5kZXYiXSw5LCIyMDI2LTA3LTEwIl0.+21jrvz5ZFmIvvA/DusCcnFV6Ab1iQQYR+INTqw/i/MmZe/5I/lhdLtqm9nprkQ1MfWL2PeyBmQui1+rjoQS1w"
+				licenseKey={TLDRAW_LICENSE_KEY}
 			/>
 		</div>
 	)

--- a/src/tldraw/license.ts
+++ b/src/tldraw/license.ts
@@ -1,0 +1,2 @@
+export const TLDRAW_LICENSE_KEY =
+	'tldraw-tldraw-2027-08-12/WyI5N2lFVC1WTiIsWyJeYXBwOi8vb2JzaWRpYW5cXC5tZChbOi9dfCQpIl0sNDEsIjIwMjctMDgtMTIiXQ.00JZlr2ebqjPfAmvg3cAq4yDUX6bYheyzH5w3wdCKA0gtptldg/bvEj0hboLD6rtAXwD/zgOicTHPhlXqmWXRw'

--- a/test/specs/license-gate.e2e.ts
+++ b/test/specs/license-gate.e2e.ts
@@ -1,0 +1,36 @@
+import { $, browser, expect } from '@wdio/globals'
+
+/**
+ * The SDK doesn't fail loudly on a bad license. `LicenseProvider` renders the editor as
+ * normal and then, five seconds later, replaces it with an empty `tl-license-expired` div —
+ * so a canvas that mounts fine can still be gone once a user has looked at it.
+ *
+ * Every other spec here finishes inside that window, which is why an expired key shipped in
+ * 1.30.0 and passed CI (#219). This one waits it out.
+ */
+describe('License', () => {
+	before(async () => {
+		await browser.reloadObsidian({
+			plugins: ['tldraw'],
+		})
+
+		await browser.executeObsidian(async ({ app }) => {
+			const plugin = (app as unknown as { plugins: { plugins: Record<string, any> } }).plugins
+				.plugins.tldraw
+			plugin.settings.fileDestinations.confirmDestination = false
+			const file = await plugin.createUntitledTldrFile({})
+			await plugin.openTldrFile(file, 'new-tab')
+		})
+	})
+
+	it('does not gate the editor once the license timeout has passed', async () => {
+		await expect($('.tldraw-view-root')).toBeExisting()
+
+		// LICENSE_TIMEOUT is 5000ms, measured from mount. Wait past it before asserting.
+		await browser.pause(8000)
+
+		await expect($('[data-testid="tl-license-expired"]')).not.toBeExisting()
+		await expect($('.tldraw-view-root')).toBeExisting()
+		await expect($('.tlui-toolbar')).toBeExisting()
+	})
+})


### PR DESCRIPTION
The plugin's license expired on 2026-08-10 and the editor went blank (#219). `97iET-VN` replaces it, and the key moves to `src/tldraw/license.ts` so there's one place to change it.

## The test

`LicenseProvider` renders the editor and only replaces it with an empty `tl-license-expired` div five seconds later. Every existing spec finishes inside that window, which is why 1.30.0 passed CI with a key that was already dead. The new spec waits it out.

## Verified

Against `@tldraw/editor` 5.2.5: valid signature, and licensed on desktop and on both mobile platforms.
