### PR TITLE
Bump tldraw to 5.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
 	"name": "tldraw-in-obsidian",
-	"version": "1.30.1",
+	"version": "1.31.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tldraw-in-obsidian",
-			"version": "1.30.1",
+			"version": "1.31.0",
 			"hasInstallScript": true,
 			"dependencies": {
 				"monkey-around": "^2.3.0",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
-				"tldraw": "^5.3.2",
+				"tldraw": "^5.4.0",
 				"zustand": "^4.3.9"
 			},
 			"devDependencies": {
@@ -49,66 +49,6 @@
 				"vite": "^8",
 				"wdio-obsidian-reporter": "^2.4.0",
 				"wdio-obsidian-service": "^2.4.0"
-			}
-		},
-		"../../../../repos/tldraw": {
-			"name": "@tldraw/monorepo",
-			"version": "0.0.0",
-			"extraneous": true,
-			"hasInstallScript": true,
-			"workspaces": [
-				"apps/*",
-				"packages/*",
-				"apps/vscode/*",
-				"config",
-				"scripts"
-			],
-			"dependencies": {
-				"@sentry/cli": "^2.25.0",
-				"@yarnpkg/types": "^4.0.0",
-				"cross-env": "^7.0.3",
-				"esbuild": "^0.21.5",
-				"mime": "^4.0.3",
-				"purgecss": "^5.0.0",
-				"svgo": "^3.0.2"
-			},
-			"devDependencies": {
-				"@microsoft/api-extractor": "^7.43.1",
-				"@next/eslint-plugin-next": "^13.3.0",
-				"@swc/core": "^1.3.55",
-				"@swc/jest": "^0.2.34",
-				"@types/glob": "^8.1.0",
-				"@types/jest": "^29.5.12",
-				"@types/node": "~20.11",
-				"@types/react": "^18.2.47",
-				"@types/react-dom": "^18.2.18",
-				"@typescript-eslint/eslint-plugin": "^5.57.0",
-				"@typescript-eslint/parser": "^5.57.0",
-				"auto": "^11.1.1",
-				"eslint": "^8.37.0",
-				"eslint-config-prettier": "^8.8.0",
-				"eslint-plugin-deprecation": "^2.0.0",
-				"eslint-plugin-import": "^2.27.5",
-				"eslint-plugin-local": "^1.0.0",
-				"eslint-plugin-no-only-tests": "^3.1.0",
-				"eslint-plugin-react": "^7.32.2",
-				"eslint-plugin-react-hooks": "^4.6.0",
-				"fs-extra": "^11.1.0",
-				"husky": "^8.0.0",
-				"jest": "30.0.0-alpha.2",
-				"json5": "^2.2.3",
-				"lazyrepo": "0.0.0-alpha.27",
-				"license-report": "^6.5.0",
-				"lint-staged": "^15.2.7",
-				"prettier": "^3.0.3",
-				"prettier-plugin-organize-imports": "^3.2.3",
-				"rimraf": "^4.4.0",
-				"tsx": "^4.0.0",
-				"typescript": "^5.3.3",
-				"vercel": "^34.2.4"
-			},
-			"engines": {
-				"npm": ">=7.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -4220,33 +4160,33 @@
 			}
 		},
 		"node_modules/@tldraw/driver": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/@tldraw/driver/-/driver-5.3.2.tgz",
-			"integrity": "sha512-OJJwgdoyJv3G2ejvQoqnNKsLphOE8SBCUkiGSZibUCt8tWFrTjvhn7aLxPcXZXtQlxHWmyE4jBvQ56Swguv/rg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@tldraw/driver/-/driver-5.4.0.tgz",
+			"integrity": "sha512-wmnQgqsuREqWgQxTDzkxxYsyMAABNJ5h0CFmPX56dxE4/HCEIyvlEkTUyTSmpiNgBknUM9R1kvy1Ktzblt+StA==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@tldraw/editor": "5.3.2",
-				"@tldraw/utils": "5.3.2"
+				"@tldraw/editor": "5.4.0",
+				"@tldraw/utils": "5.4.0"
 			},
 			"engines": {
 				"node": ">=22.12.0"
 			}
 		},
 		"node_modules/@tldraw/editor": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/@tldraw/editor/-/editor-5.3.2.tgz",
-			"integrity": "sha512-4b3aAXNU/CP2soIBuJmyom9Im5/N5Gm+6nBDbHr2yjQ/4CvP047z8ru97Au0YCvK8hF9sg/Ufk18NrBV/3pqlw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@tldraw/editor/-/editor-5.4.0.tgz",
+			"integrity": "sha512-sQ/hkGSLxkEiqLN4yiOwOI5dtweI190CL6rq0lq+9ZFf8Tl2EbVrvBCrrYXfkO8pG3TUvuHxEkLEDIWnHh0big==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@tiptap/core": "^3.12.1",
 				"@tiptap/pm": "^3.12.1",
 				"@tiptap/react": "^3.12.1",
-				"@tldraw/state": "5.3.2",
-				"@tldraw/state-react": "5.3.2",
-				"@tldraw/store": "5.3.2",
-				"@tldraw/tlschema": "5.3.2",
-				"@tldraw/utils": "5.3.2",
-				"@tldraw/validate": "5.3.2",
+				"@tldraw/state": "5.4.0",
+				"@tldraw/state-react": "5.4.0",
+				"@tldraw/store": "5.4.0",
+				"@tldraw/tlschema": "5.4.0",
+				"@tldraw/utils": "5.4.0",
+				"@tldraw/validate": "5.4.0",
 				"classnames": "^2.5.1",
 				"eventemitter3": "^4.0.7",
 				"idb": "^7.1.1",
@@ -4262,22 +4202,22 @@
 			}
 		},
 		"node_modules/@tldraw/editor/node_modules/@tiptap/core": {
-			"version": "3.30.1",
-			"resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.30.1.tgz",
-			"integrity": "sha512-HWEO6Qi8fI8Zt8X4atVV6GxthJx7Vrjr6L5YFq4OkjYJ7HG2/bFw6IKsDA3jOYgY4DM9lv8IadaiWUQ2JJRIBA==",
+			"version": "3.31.3",
+			"resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.31.3.tgz",
+			"integrity": "sha512-Cz50pvciQrxdSxgTkHOVz0uD0Yl/8Xt0QatGD6ILm47jW8EzyHR9RkUGs/D5IqzXKuVPntfw1ttaT926vXfiRg==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
 			},
 			"peerDependencies": {
-				"@tiptap/pm": "3.30.1"
+				"@tiptap/pm": "3.31.3"
 			}
 		},
 		"node_modules/@tldraw/editor/node_modules/@tiptap/extension-bubble-menu": {
-			"version": "3.30.1",
-			"resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.30.1.tgz",
-			"integrity": "sha512-6asFH7ZW0gTh0aX7qrABYRVqiU/IOSjk4PKt6qdZM5YS455bjVLZDM0PcIccMDaYiomuCNjfuCSj5dxmPDoWiQ==",
+			"version": "3.31.3",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.31.3.tgz",
+			"integrity": "sha512-EV6ZnwKc++2OM/OcD54n8s1B7C9LP7GKAtdEPwu0t3BYJf3sG8Ueoinf7SgGPO9oMPg96GneOkDNm1urMV167g==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -4288,14 +4228,14 @@
 				"url": "https://github.com/sponsors/ueberdosis"
 			},
 			"peerDependencies": {
-				"@tiptap/core": "3.30.1",
-				"@tiptap/pm": "3.30.1"
+				"@tiptap/core": "3.31.3",
+				"@tiptap/pm": "3.31.3"
 			}
 		},
 		"node_modules/@tldraw/editor/node_modules/@tiptap/extension-floating-menu": {
-			"version": "3.30.1",
-			"resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.30.1.tgz",
-			"integrity": "sha512-/Rlqsn7OXThZNzD0Qq/Ru4rZCFj3YnxL8Vf01cez+pvcyxgbwf4b9Wir+1JWJmaEMYsmWprSgEBW0l9ctbq97w==",
+			"version": "3.31.3",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.31.3.tgz",
+			"integrity": "sha512-rd4VJ9PGSP9Eop8ZTEwaLZcMzMXLuJKe3hUNf58rq+zANpwM+9fI+vB7g9MAc3eXwUNDxNDVACFIL2oeBqpQ3A==",
 			"license": "MIT",
 			"optional": true,
 			"funding": {
@@ -4304,14 +4244,14 @@
 			},
 			"peerDependencies": {
 				"@floating-ui/dom": "^1.0.0",
-				"@tiptap/core": "3.30.1",
-				"@tiptap/pm": "3.30.1"
+				"@tiptap/core": "3.31.3",
+				"@tiptap/pm": "3.31.3"
 			}
 		},
 		"node_modules/@tldraw/editor/node_modules/@tiptap/pm": {
-			"version": "3.30.1",
-			"resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.30.1.tgz",
-			"integrity": "sha512-2bHY+ihexKpfBURbAD+ahY0+lWle0TueTK80GAGYqZ/G7ErAPOmzN5RVAGMyZJI4wDkcFycRNLi3k0/3VT9a1A==",
+			"version": "3.31.3",
+			"resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.31.3.tgz",
+			"integrity": "sha512-sZime0SWsz/k62W2WvHx5Ig7G2h7kVhrrmnqy+wEgIHfDwEfOlelRjaWCiBCFlF7dxGUntJusCh9FxlLhni0Ag==",
 			"license": "MIT",
 			"dependencies": {
 				"prosemirror-changeset": "^2.4.1",
@@ -4326,7 +4266,7 @@
 				"prosemirror-state": "^1.4.4",
 				"prosemirror-tables": "^1.8.5",
 				"prosemirror-transform": "^1.12.0",
-				"prosemirror-view": "^1.41.9"
+				"prosemirror-view": "^1.42.3"
 			},
 			"funding": {
 				"type": "github",
@@ -4334,9 +4274,9 @@
 			}
 		},
 		"node_modules/@tldraw/editor/node_modules/@tiptap/react": {
-			"version": "3.30.1",
-			"resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.30.1.tgz",
-			"integrity": "sha512-SZvUkUlRpZxzNHcQsBeiExWG6vEAdk2y/YeiwHaVmTJAiFaA5+IhKW/MuN1qJEvYS5LXE0uFy/VJaZtfKV5uWw==",
+			"version": "3.31.3",
+			"resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.31.3.tgz",
+			"integrity": "sha512-QiwQqvaLFLm5EMFu5tg7nAgXJxCUiUTLD8EsK+TqVV5P4bqOoMOCM39khbhXTJyahCuYpiFWx5YOSDtC/JiPtg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/use-sync-external-store": "^0.0.6",
@@ -4348,12 +4288,12 @@
 				"url": "https://github.com/sponsors/ueberdosis"
 			},
 			"optionalDependencies": {
-				"@tiptap/extension-bubble-menu": "^3.30.1",
-				"@tiptap/extension-floating-menu": "^3.30.1"
+				"@tiptap/extension-bubble-menu": "^3.31.3",
+				"@tiptap/extension-floating-menu": "^3.31.3"
 			},
 			"peerDependencies": {
-				"@tiptap/core": "3.30.1",
-				"@tiptap/pm": "3.30.1",
+				"@tiptap/core": "3.31.3",
+				"@tiptap/pm": "3.31.3",
 				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -4370,25 +4310,25 @@
 			}
 		},
 		"node_modules/@tldraw/state": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/@tldraw/state/-/state-5.3.2.tgz",
-			"integrity": "sha512-kuWsGhao4HkbDwsBfVryRZ8kU6rEWhiA26qpRJ71nS1GXLsQwJarZ5paQzsr14bE27K+D7mJ6qw2couqqKQQJg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@tldraw/state/-/state-5.4.0.tgz",
+			"integrity": "sha512-ZymyURBo36GgDb7gZmaSCFpZIH1HoxTi4XqqYQ4yCD4T+hfUAHhNkeE+Knc7ApJ90KPjI3/rsAkFGHtNaF7zaA==",
 			"license": "MIT",
 			"dependencies": {
-				"@tldraw/utils": "5.3.2"
+				"@tldraw/utils": "5.4.0"
 			},
 			"engines": {
 				"node": ">=22.12.0"
 			}
 		},
 		"node_modules/@tldraw/state-react": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/@tldraw/state-react/-/state-react-5.3.2.tgz",
-			"integrity": "sha512-6QBvhHrLu+jlcPh15VWOlhbTgvF7S2qOgYkE9BlXwxNaDn9nriDKAlyUO5vCkERdGfV/2zkk768RhEgGXHTi8A==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@tldraw/state-react/-/state-react-5.4.0.tgz",
+			"integrity": "sha512-3nAoeDNB8UP244/2SvT5KIETK9RORlmqxxUaELoC/j7wiY8U0l7gXnzpguqt4+kLMR3GqyFM2c7BWsQrChF3xw==",
 			"license": "MIT",
 			"dependencies": {
-				"@tldraw/state": "5.3.2",
-				"@tldraw/utils": "5.3.2"
+				"@tldraw/state": "5.4.0",
+				"@tldraw/utils": "5.4.0"
 			},
 			"engines": {
 				"node": ">=22.12.0"
@@ -4399,13 +4339,13 @@
 			}
 		},
 		"node_modules/@tldraw/store": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/@tldraw/store/-/store-5.3.2.tgz",
-			"integrity": "sha512-hnl8Ianf1CSz4ZcxUt+phxyrBRyvOfCngTrhoXBEiFQY1XFYz2NZ5OLJy3AOrqm/+Z11qnSlrq6GQuhUT0ou5A==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@tldraw/store/-/store-5.4.0.tgz",
+			"integrity": "sha512-XFNU1HbVMIxzBjcFKpmNEkPp+JrkA7WXrDnYfdvFxHcEnWhvUIAnSLWRtHZv7skTAiLq1TeX7QcrA0AheQmxjg==",
 			"license": "MIT",
 			"dependencies": {
-				"@tldraw/state": "5.3.2",
-				"@tldraw/utils": "5.3.2"
+				"@tldraw/state": "5.4.0",
+				"@tldraw/utils": "5.4.0"
 			},
 			"engines": {
 				"node": ">=22.12.0"
@@ -4415,15 +4355,15 @@
 			}
 		},
 		"node_modules/@tldraw/tlschema": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/@tldraw/tlschema/-/tlschema-5.3.2.tgz",
-			"integrity": "sha512-2lkWWJLcRhUI6bHT/CNxn5ooZJQONStmF3tTcVVt3RIILBFU4xhoPaojNmZBkF90oKLOkU2CEmR7q/OFJfk8kg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@tldraw/tlschema/-/tlschema-5.4.0.tgz",
+			"integrity": "sha512-OASjD4FBI99dngq8h3TPS0RKarOG5s+feo/HaUuDY11WX6QK/c9A2TecFY5kIXk7vYQl5TDF5QXMCcnjjLm1cw==",
 			"license": "MIT",
 			"dependencies": {
-				"@tldraw/state": "5.3.2",
-				"@tldraw/store": "5.3.2",
-				"@tldraw/utils": "5.3.2",
-				"@tldraw/validate": "5.3.2"
+				"@tldraw/state": "5.4.0",
+				"@tldraw/store": "5.4.0",
+				"@tldraw/utils": "5.4.0",
+				"@tldraw/validate": "5.4.0"
 			},
 			"engines": {
 				"node": ">=22.12.0"
@@ -4434,9 +4374,9 @@
 			}
 		},
 		"node_modules/@tldraw/utils": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/@tldraw/utils/-/utils-5.3.2.tgz",
-			"integrity": "sha512-rYike11hMqEOPCHVDUtYCwD383G+3Ep6ddK/49p39oTxScZEafpEPs1wNMeke6lKtk/9eU6CFfLM88hHMDAumw==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@tldraw/utils/-/utils-5.4.0.tgz",
+			"integrity": "sha512-iIEzYVPg/iS2DDbPEbd8s+bouNxx600LzFTvYViEl8kuEW9Lt4nPYoFN7PceSedNcXL8yaSsfgW9iUP/mP2Ang==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"lodash.isequal": "^4.5.0",
@@ -4449,12 +4389,12 @@
 			}
 		},
 		"node_modules/@tldraw/validate": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/@tldraw/validate/-/validate-5.3.2.tgz",
-			"integrity": "sha512-JFsbfE3aJq3b2Xrd6Oq0P5Y3A8BrLS3vHrp/izI8VSm+Zun/NejarSavjGaDyUeR6SrTTSeHObyt8O5Ln3mnaA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@tldraw/validate/-/validate-5.4.0.tgz",
+			"integrity": "sha512-3sXwAFb4i7MzHtkKII3iwl+muFkaJ08WV6duuk30SJZwJEK1w4FddPwZoZQ23oa92snAdeGAC3qBA/mE0FU4/A==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@tldraw/utils": "5.3.2"
+				"@tldraw/utils": "5.4.0"
 			},
 			"engines": {
 				"node": ">=22.12.0"
@@ -9914,9 +9854,9 @@
 			}
 		},
 		"node_modules/is-plain-object": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.1.0.tgz",
+			"integrity": "sha512-bUi/yjmtKYcRVUtWRGr0UA6xEFh2I6zWUwMrUXB3s7bmYCaZ8a+0ZsTRkrawh/mzlSD1Y0Ph8bp/U+TvBpWDNw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -12447,9 +12387,9 @@
 			}
 		},
 		"node_modules/prosemirror-view": {
-			"version": "1.42.2",
-			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
-			"integrity": "sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==",
+			"version": "1.42.3",
+			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.3.tgz",
+			"integrity": "sha512-oTN7EtH+CpwxU9NrwEYWd0UZ4JUx7l048l5A2Xppm4p/60isZYLnth9QVQmC3VRIvdrIWCxwZSd+Uz791G31/w==",
 			"license": "MIT",
 			"dependencies": {
 				"prosemirror-model": "^1.25.8",
@@ -14287,9 +14227,9 @@
 			}
 		},
 		"node_modules/tldraw": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/tldraw/-/tldraw-5.3.2.tgz",
-			"integrity": "sha512-HniH9yXFSKQ2l73i2c6+dfZ3SOS9avip+xmJqi69FiZahgIzMKrAtXs8XVwUCgJT9i4Z+KCogW6rWgY3O0iXOA==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/tldraw/-/tldraw-5.4.0.tgz",
+			"integrity": "sha512-4iNNAC/eV9Wa3unLBs9XIXh9lv+ZL8tPJYbVKkFmItDcKHL2bQ11OvltWEHY3Fp8Wk5v29C3qLmQxrBAoAGDWw==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@tiptap/core": "^3.12.1",
@@ -14299,11 +14239,11 @@
 				"@tiptap/pm": "^3.12.1",
 				"@tiptap/react": "^3.12.1",
 				"@tiptap/starter-kit": "^3.12.1",
-				"@tldraw/driver": "5.3.2",
-				"@tldraw/editor": "5.3.2",
-				"@tldraw/state": "5.3.2",
-				"@tldraw/store": "5.3.2",
-				"@tldraw/tlschema": "5.3.2",
+				"@tldraw/driver": "5.4.0",
+				"@tldraw/editor": "5.4.0",
+				"@tldraw/state": "5.4.0",
+				"@tldraw/store": "5.4.0",
+				"@tldraw/tlschema": "5.4.0",
 				"classnames": "^2.5.1",
 				"idb": "^7.1.1",
 				"lz-string": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 		"monkey-around": "^2.3.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"tldraw": "^5.3.2",
+		"tldraw": "^5.4.0",
 		"zustand": "^4.3.9"
 	}
 }


### PR DESCRIPTION
Updates the bundled tldraw SDK from `^5.3.2` to `^5.4.0`. Release notes: https://github.com/tldraw/tldraw/releases/tag/v5.4.0

No source changes were needed. The plugin builds cleanly against 5.4.0 and `src` typechecks with no errors.

## Verified

- `npm run build` (production, so the license check is enforced) succeeds and reports `TLDRAW_VERSION: '5.4.0'`.
- `npx tsc --noEmit` reports no errors under `src`.
- `npm run lint` reports the same 63 pre-existing errors as `main`, none introduced here.
- `npm run e2e` locally on macOS: 7 of 8 specs pass. The one failure, `theme-background` "follows the Obsidian theme when it changes", fails identically when run against the released 1.31.0 build (`TLDRAW_PLUGIN_VERSION=1.31.0`), which still bundles 5.3.2. Its guard assertion fires because Obsidian's own background never changes in that local harness, so it is unrelated to this bump. The suite passes on CI's Ubuntu runner for `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRSZqZtC4t1yrhrVY5dvxL